### PR TITLE
Updated URL for Shop Index

### DIFF
--- a/commands.sk
+++ b/commands.sk
@@ -54,7 +54,7 @@ command /links:
         message "&f• &3survival.gamealition.com/features &f- Features"
         message "&f• &3survival.gamealition.com/changelog &f- Changelog"
         message "&f• &3survival.gamealition.com/bugs &f- Known issues"
-        message "&f• &3laken.me/mcshop &f- Stitch's Shop Index &7&o(third-party)"
+        message "&f• &3stitchhasaglitch.com/mcshopdex &f- Stitch's Shop Index &7&o(third-party)"
 
 command /color:
     description: Prints a list of formatting codes


### PR DESCRIPTION
I've updated the link for the shop index for the `/www`/`/links` command.

Untested, however I don't see how I could have broken something.